### PR TITLE
Fix issue with unknown key detection.

### DIFF
--- a/Interface.cpp
+++ b/Interface.cpp
@@ -3524,7 +3524,7 @@ bool GetButtonText( const BUTTON &btnButton, LPTSTR Buffer )
 DWORD ScanKeyboard( LPDEVICE lpDevice, LPDWORD lpdwCounter, LPBUTTON pButton )
 {
 	HRESULT hr;
-	BYTE cKeys[256];
+	BYTE cKeys[256] = {0};
 
 	hr = lpDevice->didHandle->GetDeviceState( sizeof( cKeys ), (LPVOID)&cKeys );
 	if ( FAILED(hr) )
@@ -3534,9 +3534,8 @@ DWORD ScanKeyboard( LPDEVICE lpDevice, LPDWORD lpdwCounter, LPBUTTON pButton )
 	}
 
 	int iGotKey = FALSE;
-	int i = 0;
 
-	for( i = 0; i < ARRAYSIZE( cKeys ); ++i )
+	for( int i = 1; i < ARRAYSIZE( cKeys ); ++i )
 	{
 		if (( cKeys[i] & 0x80 ) )
 		{


### PR DESCRIPTION
Howdy,

I don't know if you are still interested in maintaining this, but this is a fix for the relatively common bug that occurs when using a Switch Pro Controller.

For some reason, after inputting a button with the Pro Controller, keyboard scancode 0 starts firing. At first I assumed this was likely to be a bug involving uninitialized stack memory, but it was not (that I could determine.) It looks like scancode 0 really is firing, even though scancode 0, for all I can tell, is a meaningless scancode. As of now, the exact cause of this is unknown.

This patch just skips the iteration of scancode 0 altogether. It also clears the cKeys array ahead of time for good measure, just in case any part of the array is not written to by `GetDeviceState`.